### PR TITLE
[codex] support bevy 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_interleave"
 description = "bevy support for e2e packed to planar bind groups"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 authors = ["mosure <mitchell@mosure.me>"]
 license = "MIT"
@@ -29,20 +29,20 @@ members = [
 
 
 [dependencies]
-bevy_interleave_interface = { path = "crates/bevy_interleave_interface", version = "0.9.0" }
-bevy_interleave_macros = { path = "crates/bevy_interleave_macros", version = "0.9.0" }
+bevy_interleave_interface = { path = "crates/bevy_interleave_interface", version = "0.10.0" }
+bevy_interleave_macros = { path = "crates/bevy_interleave_macros", version = "0.10.0" }
 bytemuck = "1.24"
 serde = "1.0"
-wgpu = "27"
+wgpu = "29"
 
 [dependencies.bevy]
-version = "0.18"
+version = "0.19"
 default-features = false
 features = ["bevy_asset", "bevy_render", "png", "reflect_documentation", "reflect_functions"]
 
 
 [dev-dependencies.bevy]
-version = "0.18"
+version = "0.19"
 default-features = false
 features = [
   "bevy_asset",
@@ -51,6 +51,7 @@ features = [
   "png",
   "reflect_documentation",
   "reflect_functions",
+  "x11",
 ]
 
 

--- a/crates/bevy_interleave_interface/Cargo.toml
+++ b/crates/bevy_interleave_interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_interleave_interface"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 description = "interface for e2e packed to planar bind groups"
 homepage = "https://github.com/mosure/bevy_interleave"
@@ -13,6 +13,6 @@ keywords = [
 
 
 [dependencies.bevy]
-version = "0.18"
+version = "0.19"
 default-features = false
 features = ["bevy_asset", "bevy_render", "png", "reflect_documentation", "reflect_functions"]

--- a/crates/bevy_interleave_interface/src/lib.rs
+++ b/crates/bevy_interleave_interface/src/lib.rs
@@ -1,7 +1,6 @@
 pub mod storage;
 // pub mod texture;
 
-
 pub trait PlanarHandle<T>
 where
     Self: bevy::ecs::component::Component,
@@ -10,11 +9,11 @@ where
     Self: bevy::reflect::FromReflect,
     Self: bevy::reflect::GetTypeRegistration,
     Self: bevy::reflect::Reflect,
+    Self: bevy::render::sync_component::SyncComponent,
     T: bevy::asset::Asset,
 {
     fn handle(&self) -> &bevy::asset::Handle<T>;
 }
-
 
 // TODO: migrate to PlanarSync
 pub trait PlanarSync
@@ -25,15 +24,11 @@ where
     Self: bevy::reflect::Reflect,
     Self: 'static,
 {
-    type PackedType;  // Self
+    type PackedType; // Self
     type PlanarType: Planar<PackedType = Self::PackedType>;
     type PlanarTypeHandle: PlanarHandle<Self::PlanarType>;
-    type GpuPlanarType: GpuPlanar<
-        PackedType = Self::PackedType,
-        PlanarType = Self::PlanarType,
-    >;
+    type GpuPlanarType: GpuPlanar<PackedType = Self::PackedType, PlanarType = Self::PlanarType>;
 }
-
 
 pub trait GpuPlanar
 where
@@ -70,8 +65,6 @@ where
     ) -> bevy::render::render_resource::BindGroupLayout;
 }
 
-
-
 pub trait GpuPlanarTexture
 where
     Self: GpuPlanar,
@@ -91,7 +84,6 @@ where
     fn get_asset_handles(&self) -> Vec<bevy::asset::Handle<bevy::image::Image>>;
 }
 
-
 // TODO: find a better name, PlanarTexture is implemented on the packed type
 pub trait PlanarTexture
 where
@@ -106,15 +98,12 @@ where
     fn get_asset_handles(&self) -> Vec<bevy::asset::Handle<bevy::image::Image>>;
 }
 
-
-
 pub trait ReflectInterleaved {
     type PackedType;
 
     fn min_binding_sizes() -> &'static [usize];
     fn ordered_field_names() -> &'static [&'static str];
 }
-
 
 pub trait Planar
 where
@@ -132,7 +121,9 @@ where
     fn set(&mut self, index: usize, value: Self::PackedType);
     fn to_interleaved(&self) -> Vec<Self::PackedType>;
 
-    fn from_interleaved(packed: Vec<Self::PackedType>) -> Self where Self: Sized;
+    fn from_interleaved(packed: Vec<Self::PackedType>) -> Self
+    where
+        Self: Sized;
 
     fn subset(&self, indices: &[usize]) -> Self;
 }

--- a/crates/bevy_interleave_interface/src/storage.rs
+++ b/crates/bevy_interleave_interface/src/storage.rs
@@ -1,16 +1,8 @@
 use std::marker::PhantomData;
 
-use bevy::{
-    prelude::*,
-    reflect::GetTypeRegistration,
-};
+use bevy::{prelude::*, reflect::GetTypeRegistration};
 
-use crate::{
-    GpuPlanarStorage,
-    PlanarHandle,
-    PlanarSync,
-};
-
+use crate::{GpuPlanarStorage, PlanarHandle, PlanarSync};
 
 pub struct PlanarStoragePlugin<R> {
     phantom: PhantomData<fn() -> R>,
@@ -36,14 +28,15 @@ where
         app.init_asset::<R::PlanarType>();
         app.register_asset_reflect::<R::PlanarType>();
 
-        app.add_plugins(bevy::render::render_asset::RenderAssetPlugin::<R::GpuPlanarType>::default());
-        app.add_plugins(bevy::render::sync_component::SyncComponentPlugin::<R::PlanarTypeHandle>::default());
+        app.add_plugins(bevy::render::render_asset::RenderAssetPlugin::<
+            R::GpuPlanarType,
+        >::default());
+        app.add_plugins(bevy::render::sync_component::SyncComponentPlugin::<
+            R::PlanarTypeHandle,
+        >::default());
 
         let render_app = app.sub_app_mut(bevy::render::RenderApp);
-        render_app.add_systems(
-            bevy::render::ExtractSchedule,
-            extract_planar_handles::<R>,
-        );
+        render_app.add_systems(bevy::render::ExtractSchedule, extract_planar_handles::<R>);
         render_app.add_systems(
             bevy::render::Render,
             queue_gpu_storage_buffers::<R>.in_set(bevy::render::RenderSystems::PrepareBindGroups),
@@ -52,11 +45,10 @@ where
 
     fn finish(&self, app: &mut App) {
         if let Some(render_app) = app.get_sub_app_mut(bevy::render::RenderApp) {
-            render_app.init_resource::<PlanarStorageLayouts::<R>>();
+            render_app.init_resource::<PlanarStorageLayouts<R>>();
         }
     }
 }
-
 
 // TODO: migrate to PlanarLayouts<R: PlanarSync>
 #[derive(bevy::prelude::Resource)]
@@ -68,8 +60,7 @@ where
     pub phantom: PhantomData<fn() -> R>,
 }
 
-impl<R: PlanarSync>
-FromWorld for PlanarStorageLayouts<R>
+impl<R: PlanarSync> FromWorld for PlanarStorageLayouts<R>
 where
     R::GpuPlanarType: GpuPlanarStorage,
 {
@@ -77,10 +68,7 @@ where
         let render_device = world.resource::<bevy::render::renderer::RenderDevice>();
 
         let read_only = true;
-        let bind_group_layout = R::GpuPlanarType::bind_group_layout(
-            render_device,
-            read_only,
-        );
+        let bind_group_layout = R::GpuPlanarType::bind_group_layout(render_device, read_only);
 
         Self {
             bind_group_layout,
@@ -95,31 +83,23 @@ pub struct PlanarStorageBindGroup<R: PlanarSync> {
     pub phantom: PhantomData<fn() -> R>,
 }
 
-
 fn extract_planar_handles<R>(
     mut commands: Commands,
     mut main_world: ResMut<bevy::render::MainWorld>,
-)
-where
+) where
     R: PlanarSync + Default + Clone + Reflect,
     R::PlanarType: Asset,
     R::GpuPlanarType: GpuPlanarStorage,
 {
-    let mut planar_handles_query = main_world.query::<(
-        bevy::render::sync_world::RenderEntity,
-        &R::PlanarTypeHandle,
-    )>();
+    let mut planar_handles_query =
+        main_world.query::<(bevy::render::sync_world::RenderEntity, &R::PlanarTypeHandle)>();
 
-    for (
-        entity,
-        planar_handle
-    ) in planar_handles_query.iter(&main_world) {
+    for (entity, planar_handle) in planar_handles_query.iter(&main_world) {
         if let Ok(mut entity_commands) = commands.get_entity(entity) {
             entity_commands.insert(planar_handle.clone());
         }
     }
 }
-
 
 fn queue_gpu_storage_buffers<R>(
     mut commands: Commands,
@@ -128,24 +108,19 @@ fn queue_gpu_storage_buffers<R>(
     gpu_planars: Res<bevy::render::render_asset::RenderAssets<R::GpuPlanarType>>,
     bind_group_layout: Res<PlanarStorageLayouts<R>>,
     clouds: Query<
-        (
-            bevy::prelude::Entity,
-            &R::PlanarTypeHandle,
-        ),
-        Without<PlanarStorageBindGroup::<R>>,
+        (bevy::prelude::Entity, &R::PlanarTypeHandle),
+        Without<PlanarStorageBindGroup<R>>,
     >,
-)
-where
+) where
     R: PlanarSync + Default + Clone + Reflect,
     R::PlanarType: Asset,
     R::GpuPlanarType: GpuPlanarStorage,
 {
     let layout = &bind_group_layout.bind_group_layout;
 
-    for (entity, planar_handle,) in clouds.iter() {
-
-        if let Some(load_state) = asset_server.get_load_state(planar_handle.handle()) 
-            && load_state.is_loading() 
+    for (entity, planar_handle) in clouds.iter() {
+        if let Some(load_state) = asset_server.get_load_state(planar_handle.handle())
+            && load_state.is_loading()
         {
             continue;
         }
@@ -154,11 +129,9 @@ where
             continue;
         }
 
-        let gpu_planar: &<R as PlanarSync>::GpuPlanarType = gpu_planars.get(planar_handle.handle()).unwrap();
-        let bind_group = gpu_planar.bind_group(
-            &render_device,
-            layout,
-        );
+        let gpu_planar: &<R as PlanarSync>::GpuPlanarType =
+            gpu_planars.get(planar_handle.handle()).unwrap();
+        let bind_group = gpu_planar.bind_group(&render_device, layout);
 
         commands.entity(entity).insert(PlanarStorageBindGroup::<R> {
             bind_group,

--- a/crates/bevy_interleave_macros/Cargo.toml
+++ b/crates/bevy_interleave_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_interleave_macros"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 description = "macros for e2e packed to planar bind groups"
 homepage = "https://github.com/mosure/bevy_interleave"
@@ -13,17 +13,17 @@ keywords = [
 
 
 [dependencies]
-bevy_interleave_interface = { path = "../bevy_interleave_interface", version = "0.9.0" }
+bevy_interleave_interface = { path = "../bevy_interleave_interface", version = "0.10.0" }
 bytemuck = "1.14"
 convert_case = "0.10"
 proc-macro2 = "1.0"
 quote = "1.0"
 sha1 = "0.10"
 syn = "2.0"
-wgpu = "27"
+wgpu = "29"
 
 [dependencies.bevy]
-version = "0.18"
+version = "0.19"
 default-features = false
 features = ["bevy_asset", "bevy_render", "png", "reflect_documentation", "reflect_functions"]
 

--- a/crates/bevy_interleave_macros/src/bindings/storage.rs
+++ b/crates/bevy_interleave_macros/src/bindings/storage.rs
@@ -1,18 +1,6 @@
-use convert_case::{
-    Case,
-    Casing,
-};
+use convert_case::{Case, Casing};
 use quote::quote;
-use syn::{
-    Data,
-    DeriveInput,
-    Error,
-    Fields,
-    FieldsNamed,
-    Ident,
-    Result,
-};
-
+use syn::{Data, DeriveInput, Error, Fields, FieldsNamed, Ident, Result};
 
 pub fn storage_bindings(input: &DeriveInput) -> Result<quote::__private::TokenStream> {
     let name = &input.ident;
@@ -27,10 +15,16 @@ pub fn storage_bindings(input: &DeriveInput) -> Result<quote::__private::TokenSt
             _ => return Err(Error::new_spanned(input, "Unsupported struct type")),
         }
     } else {
-        return Err(Error::new_spanned(input, "Planar macro only supports structs"));
+        return Err(Error::new_spanned(
+            input,
+            "Planar macro only supports structs",
+        ));
     };
 
-    let field_names = fields_struct.named.iter().map(|f| f.ident.as_ref().unwrap());
+    let field_names = fields_struct
+        .named
+        .iter()
+        .map(|f| f.ident.as_ref().unwrap());
     let field_types = fields_struct.named.iter().map(|_| {
         quote! { bevy::render::render_resource::Buffer }
     });
@@ -38,28 +32,24 @@ pub fn storage_bindings(input: &DeriveInput) -> Result<quote::__private::TokenSt
     let bind_group = generate_bind_group_method(name, fields_struct);
     let bind_group_layout = generate_bind_group_layout_method(name, fields_struct);
 
-    let buffers = field_names
-        .clone()
-        .map(|name| {
-            let buffer_name_string = format!("{name}_buffer");
+    let buffers = field_names.clone().map(|name| {
+        let buffer_name_string = format!("{name}_buffer");
 
-            quote! {
-                let #name = render_device.create_buffer_with_data(
-                    &bevy::render::render_resource::BufferInitDescriptor {
-                        label: Some(#buffer_name_string),
-                        contents: bytemuck::cast_slice(source.#name.as_slice()),
-                        usage: bevy::render::render_resource::BufferUsages::COPY_DST
-                             | bevy::render::render_resource::BufferUsages::STORAGE,
-                    }
-                );
-            }
-        });
+        quote! {
+            let #name = render_device.create_buffer_with_data(
+                &bevy::render::render_resource::BufferInitDescriptor {
+                    label: Some(#buffer_name_string),
+                    contents: bytemuck::cast_slice(source.#name.as_slice()),
+                    usage: bevy::render::render_resource::BufferUsages::COPY_DST
+                         | bevy::render::render_resource::BufferUsages::STORAGE,
+                }
+            );
+        }
+    });
 
-    let buffer_names = field_names
-        .clone()
-        .map(|name| {
-            quote! { #name }
-        });
+    let buffer_names = field_names.clone().map(|name| {
+        quote! { #name }
+    });
 
     let expanded = quote! {
         #[derive(Debug, Clone)]
@@ -139,29 +129,28 @@ pub fn storage_bindings(input: &DeriveInput) -> Result<quote::__private::TokenSt
     Ok(expanded)
 }
 
-
-pub fn generate_bind_group_method(struct_name: &Ident, fields_named: &FieldsNamed) -> quote::__private::TokenStream {
+pub fn generate_bind_group_method(
+    struct_name: &Ident,
+    fields_named: &FieldsNamed,
+) -> quote::__private::TokenStream {
     let struct_name_snake = struct_name.to_string().to_case(Case::Snake);
     let bind_group_name = format!("storage_{struct_name_snake}_bind_group");
 
-    let bind_group_entries = fields_named.named
-        .iter()
-        .enumerate()
-        .map(|(idx, field)| {
-            let name = field.ident.as_ref().unwrap();
-            quote! {
-                bevy::render::render_resource::BindGroupEntry {
-                    binding: #idx as u32,
-                    resource: bevy::render::render_resource::BindingResource::Buffer(
-                        bevy::render::render_resource::BufferBinding {
-                            buffer: &self.#name,
-                            offset: 0,
-                            size: bevy::render::render_resource::BufferSize::new(self.#name.size()),
-                        }
-                    ),
-                },
-            }
-        });
+    let bind_group_entries = fields_named.named.iter().enumerate().map(|(idx, field)| {
+        let name = field.ident.as_ref().unwrap();
+        quote! {
+            bevy::render::render_resource::BindGroupEntry {
+                binding: #idx as u32,
+                resource: bevy::render::render_resource::BindingResource::Buffer(
+                    bevy::render::render_resource::BufferBinding {
+                        buffer: &self.#name,
+                        offset: 0,
+                        size: bevy::render::render_resource::BufferSize::new(self.#name.size()),
+                    }
+                ),
+            },
+        }
+    });
 
     quote! {
         fn bind_group(
@@ -180,8 +169,10 @@ pub fn generate_bind_group_method(struct_name: &Ident, fields_named: &FieldsName
     }
 }
 
-
-pub fn generate_bind_group_layout_method(struct_name: &Ident, fields_named: &FieldsNamed) -> quote::__private::TokenStream {
+pub fn generate_bind_group_layout_method(
+    struct_name: &Ident,
+    fields_named: &FieldsNamed,
+) -> quote::__private::TokenStream {
     let struct_name_snake = struct_name.to_string().to_case(Case::Snake);
     let bind_group_layout_name = format!("storage_{struct_name_snake}_bind_group_layout");
 

--- a/crates/bevy_interleave_macros/src/bindings/texture.rs
+++ b/crates/bevy_interleave_macros/src/bindings/texture.rs
@@ -1,25 +1,10 @@
-use convert_case::{
-    Case,
-    Casing,
-};
+use convert_case::{Case, Casing};
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
-    Attribute,
-    Data,
-    DeriveInput,
-    Error,
-    Fields,
-    FieldsNamed,
-    Ident,
-    parse::{
-        Parse,
-        ParseStream,
-    },
-    Path,
-    Result,
+    Attribute, Data, DeriveInput, Error, Fields, FieldsNamed, Ident, Path, Result,
+    parse::{Parse, ParseStream},
 };
-
 
 pub fn texture_bindings(input: &DeriveInput) -> Result<quote::__private::TokenStream> {
     let name = &input.ident;
@@ -34,10 +19,16 @@ pub fn texture_bindings(input: &DeriveInput) -> Result<quote::__private::TokenSt
             _ => return Err(Error::new_spanned(input, "Unsupported struct type")),
         }
     } else {
-        return Err(Error::new_spanned(input, "Planar macro only supports structs"));
+        return Err(Error::new_spanned(
+            input,
+            "Planar macro only supports structs",
+        ));
     };
 
-    let field_names = fields_struct.named.iter().map(|f| f.ident.as_ref().unwrap());
+    let field_names = fields_struct
+        .named
+        .iter()
+        .map(|f| f.ident.as_ref().unwrap());
     let field_types = fields_struct.named.iter().map(|_| {
         quote! { bevy::asset::Handle<bevy::image::Image> }
     });
@@ -47,11 +38,9 @@ pub fn texture_bindings(input: &DeriveInput) -> Result<quote::__private::TokenSt
     let prepare = generate_prepare_method(fields_struct);
     let get_asset_handles = generate_get_asset_handles_method(fields_struct);
 
-    let handle_clones = field_names
-        .clone()
-        .map(|name| {
-            quote! { #name: source.#name.clone() }
-        });
+    let handle_clones = field_names.clone().map(|name| {
+        quote! { #name: source.#name.clone() }
+    });
 
     let expanded = quote! {
         #[derive(Debug, Clone)]
@@ -109,25 +98,24 @@ pub fn texture_bindings(input: &DeriveInput) -> Result<quote::__private::TokenSt
     Ok(expanded)
 }
 
-
-pub fn generate_bind_group_method(struct_name: &Ident, fields_named: &FieldsNamed) -> quote::__private::TokenStream {
+pub fn generate_bind_group_method(
+    struct_name: &Ident,
+    fields_named: &FieldsNamed,
+) -> quote::__private::TokenStream {
     let struct_name_snake = struct_name.to_string().to_case(Case::Snake);
     let bind_group_name = format!("texture_{struct_name_snake}_bind_group");
 
-    let bind_group_entries = fields_named.named
-        .iter()
-        .enumerate()
-        .map(|(idx, field)| {
-            let name = field.ident.as_ref().unwrap();
-            quote! {
-                bevy::render::render_resource::BindGroupEntry {
-                    binding: #idx as u32,
-                    resource: bevy::render::render_resource::BindingResource::TextureView(
-                        &gpu_images.get(&self.#name).unwrap().texture_view
-                    ),
-                },
-            }
-        });
+    let bind_group_entries = fields_named.named.iter().enumerate().map(|(idx, field)| {
+        let name = field.ident.as_ref().unwrap();
+        quote! {
+            bevy::render::render_resource::BindGroupEntry {
+                binding: #idx as u32,
+                resource: bevy::render::render_resource::BindingResource::TextureView(
+                    &gpu_images.get(&self.#name).unwrap().texture_view
+                ),
+            },
+        }
+    });
 
     quote! {
         fn bind_group(
@@ -147,53 +135,50 @@ pub fn generate_bind_group_method(struct_name: &Ident, fields_named: &FieldsName
     }
 }
 
-
-pub fn generate_bind_group_layout_method(struct_name: &Ident, fields_named: &FieldsNamed) -> quote::__private::TokenStream {
+pub fn generate_bind_group_layout_method(
+    struct_name: &Ident,
+    fields_named: &FieldsNamed,
+) -> quote::__private::TokenStream {
     let struct_name_snake = struct_name.to_string().to_case(Case::Snake);
     let bind_group_layout_name = format!("texture_{struct_name_snake}_bind_group_layout");
 
-    let bind_group_layout_entries = fields_named.named
-        .iter()
-        .enumerate()
-        .map(|(idx, field)| {
-            let name = field.ident.as_ref().unwrap();
-            let format = extract_texture_format(&field.attrs);
+    let bind_group_layout_entries = fields_named.named.iter().enumerate().map(|(idx, field)| {
+        let name = field.ident.as_ref().unwrap();
+        let format = extract_texture_format(&field.attrs);
 
-            let field_type = &field.ty;
+        let field_type = &field.ty;
 
-            quote! {
-                let sample_type = #format.sample_type(None, None).unwrap();
+        quote! {
+            let sample_type = #format.sample_type(None, None).unwrap();
 
-                let size = std::mem::size_of::<#field_type>();
-                let format_bpp = #format.pixel_size();
-                let depth = (size as f32 / format_bpp as f32).ceil() as u32;
+            let size = std::mem::size_of::<#field_type>();
+            let format_bpp = #format.pixel_size();
+            let depth = (size as f32 / format_bpp as f32).ceil() as u32;
 
-                let view_dimension = if depth == 1 {
-                    bevy::render::render_resource::TextureViewDimension::D2  // TODO: support 3D texture sampling
-                } else {
-                    bevy::render::render_resource::TextureViewDimension::D2Array
-                };
+            let view_dimension = if depth == 1 {
+                bevy::render::render_resource::TextureViewDimension::D2  // TODO: support 3D texture sampling
+            } else {
+                bevy::render::render_resource::TextureViewDimension::D2Array
+            };
 
-                let #name = bevy::render::render_resource::BindGroupLayoutEntry {
-                    binding: #idx as u32,
-                    visibility: bevy::render::render_resource::ShaderStages::VERTEX_FRAGMENT
-                        | bevy::render::render_resource::ShaderStages::COMPUTE,
-                    ty: bevy::render::render_resource::BindingType::Texture {
-                        view_dimension,
-                        sample_type,
-                        multisampled: false,
-                    },
-                    count: None,
-                };
-            }
-        });
+            let #name = bevy::render::render_resource::BindGroupLayoutEntry {
+                binding: #idx as u32,
+                visibility: bevy::render::render_resource::ShaderStages::VERTEX_FRAGMENT
+                    | bevy::render::render_resource::ShaderStages::COMPUTE,
+                ty: bevy::render::render_resource::BindingType::Texture {
+                    view_dimension,
+                    sample_type,
+                    multisampled: false,
+                },
+                count: None,
+            };
+        }
+    });
 
-    let layout_names = fields_named.named
-        .iter()
-        .map(|field| {
-            let name = field.ident.as_ref().unwrap();
-            quote! { #name }
-        });
+    let layout_names = fields_named.named.iter().map(|field| {
+        let name = field.ident.as_ref().unwrap();
+        quote! { #name }
+    });
 
     quote! {
         fn bind_group_layout(
@@ -211,49 +196,44 @@ pub fn generate_bind_group_layout_method(struct_name: &Ident, fields_named: &Fie
     }
 }
 
-
 pub fn generate_prepare_method(fields_named: &FieldsNamed) -> quote::__private::TokenStream {
-    let buffers = fields_named.named
-        .iter()
-        .map(|field| {
-            let name = field.ident.as_ref().unwrap();
-            let format = extract_texture_format(&field.attrs);
+    let buffers = fields_named.named.iter().map(|field| {
+        let name = field.ident.as_ref().unwrap();
+        let format = extract_texture_format(&field.attrs);
 
-            let field_type = &field.ty;
+        let field_type = &field.ty;
 
-            quote! {
-                let square = (self.#name.len() as f32).sqrt().ceil() as u32;
+        quote! {
+            let square = (self.#name.len() as f32).sqrt().ceil() as u32;
 
-                let size = std::mem::size_of::<#field_type>();
-                let format_bpp = #format.pixel_size();
-                let depth = (size as f32 / format_bpp as f32).ceil() as u32;
+            let size = std::mem::size_of::<#field_type>();
+            let format_bpp = #format.pixel_size();
+            let depth = (size as f32 / format_bpp as f32).ceil() as u32;
 
-                let mut data = bytemuck::cast_slice(self.#name.as_slice()).to_vec();
+            let mut data = bytemuck::cast_slice(self.#name.as_slice()).to_vec();
 
-                let padded_size = (square * square * depth * format_bpp as u32) as usize;
-                data.resize(padded_size, 0);
+            let padded_size = (square * square * depth * format_bpp as u32) as usize;
+            data.resize(padded_size, 0);
 
-                let mut #name = bevy::image::Image::new(
-                    bevy::render::render_resource::Extent3d {
-                        width: square,
-                        height: square,
-                        depth_or_array_layers: depth,
-                    },
-                    bevy::render::render_resource::TextureDimension::D2,
-                    data,
-                    #format,
-                    bevy::render::render_asset::RenderAssetUsages::default(),  // TODO: if there are no CPU image derived features, set to render only
-                );
-                let #name = images.add(#name);
-            }
-        });
+            let mut #name = bevy::image::Image::new(
+                bevy::render::render_resource::Extent3d {
+                    width: square,
+                    height: square,
+                    depth_or_array_layers: depth,
+                },
+                bevy::render::render_resource::TextureDimension::D2,
+                data,
+                #format,
+                bevy::render::render_asset::RenderAssetUsages::default(),  // TODO: if there are no CPU image derived features, set to render only
+            );
+            let #name = images.add(#name);
+        }
+    });
 
-    let buffer_names = fields_named.named
-        .iter()
-        .map(|field| {
-            let name = field.ident.as_ref().unwrap();
-            quote! { #name }
-        });
+    let buffer_names = fields_named.named.iter().map(|field| {
+        let name = field.ident.as_ref().unwrap();
+        quote! { #name }
+    });
 
     quote! {
         fn prepare(
@@ -269,14 +249,13 @@ pub fn generate_prepare_method(fields_named: &FieldsNamed) -> quote::__private::
     }
 }
 
-
-pub fn generate_get_asset_handles_method(fields_named: &FieldsNamed) -> quote::__private::TokenStream {
-    let buffer_names = fields_named.named
-        .iter()
-        .map(|field| {
-            let name = field.ident.as_ref().unwrap();
-            quote! { self.#name.clone() }
-        });
+pub fn generate_get_asset_handles_method(
+    fields_named: &FieldsNamed,
+) -> quote::__private::TokenStream {
+    let buffer_names = fields_named.named.iter().map(|field| {
+        let name = field.ident.as_ref().unwrap();
+        quote! { self.#name.clone() }
+    });
 
     quote! {
         fn get_asset_handles(&self) -> Vec<bevy::asset::Handle<bevy::image::Image>> {
@@ -286,7 +265,6 @@ pub fn generate_get_asset_handles_method(fields_named: &FieldsNamed) -> quote::_
         }
     }
 }
-
 
 struct TextureFormatAttr(Path);
 
@@ -309,5 +287,7 @@ fn extract_texture_format(attributes: &[Attribute]) -> TokenStream {
         }
     }
 
-    panic!("no texture_format attribute found, add `#[texture_format(Ident)]` to the field declarations");
+    panic!(
+        "no texture_format attribute found, add `#[texture_format(Ident)]` to the field declarations"
+    );
 }

--- a/crates/bevy_interleave_macros/src/lib.rs
+++ b/crates/bevy_interleave_macros/src/lib.rs
@@ -1,11 +1,7 @@
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
-use syn::{
-    DeriveInput,
-    parse_macro_input,
-};
-
+use syn::{DeriveInput, parse_macro_input};
 
 mod planar;
 use planar::generate_planar_struct;
@@ -22,7 +18,6 @@ pub fn planar_macro_derive(input: TokenStream) -> TokenStream {
     TokenStream::from(output)
 }
 
-
 mod packed;
 use packed::generate_reflect_interleaved;
 
@@ -38,7 +33,6 @@ pub fn reflect_interleaved_macro_derive(input: TokenStream) -> TokenStream {
     TokenStream::from(output)
 }
 
-
 mod bindings;
 use bindings::storage::storage_bindings;
 
@@ -53,7 +47,6 @@ pub fn storage_bindings_macro_derive(input: TokenStream) -> TokenStream {
 
     TokenStream::from(output)
 }
-
 
 use bindings::texture::texture_bindings;
 

--- a/crates/bevy_interleave_macros/src/packed.rs
+++ b/crates/bevy_interleave_macros/src/packed.rs
@@ -1,13 +1,5 @@
 use quote::quote;
-use syn::{
-    Data,
-    DeriveInput,
-    Error,
-    Fields,
-    FieldsNamed,
-    Result,
-};
-
+use syn::{Data, DeriveInput, Error, Fields, FieldsNamed, Result};
 
 pub fn generate_reflect_interleaved(input: &DeriveInput) -> Result<quote::__private::TokenStream> {
     let name = &input.ident;
@@ -18,7 +10,10 @@ pub fn generate_reflect_interleaved(input: &DeriveInput) -> Result<quote::__priv
             _ => return Err(Error::new_spanned(input, "Unsupported struct type")),
         }
     } else {
-        return Err(Error::new_spanned(input, "Planar macro only supports structs"));
+        return Err(Error::new_spanned(
+            input,
+            "Planar macro only supports structs",
+        ));
     };
 
     let min_binding_size_method = generate_min_binding_size_method(fields_struct);
@@ -36,16 +31,15 @@ pub fn generate_reflect_interleaved(input: &DeriveInput) -> Result<quote::__priv
     Ok(expanded)
 }
 
-
-pub fn generate_min_binding_size_method(fields_named: &FieldsNamed) -> quote::__private::TokenStream {
-    let min_binding_sizes = fields_named.named
-        .iter()
-        .map(|f| {
-            let field_type = &f.ty;
-            quote! {
-                std::mem::size_of::<#field_type>()
-            }
-        });
+pub fn generate_min_binding_size_method(
+    fields_named: &FieldsNamed,
+) -> quote::__private::TokenStream {
+    let min_binding_sizes = fields_named.named.iter().map(|f| {
+        let field_type = &f.ty;
+        quote! {
+            std::mem::size_of::<#field_type>()
+        }
+    });
 
     quote! {
         fn min_binding_sizes() -> &'static [usize] {
@@ -54,15 +48,14 @@ pub fn generate_min_binding_size_method(fields_named: &FieldsNamed) -> quote::__
     }
 }
 
-
-pub fn generate_ordered_field_names_method(fields_named: &FieldsNamed) -> quote::__private::TokenStream {
-    let string_field_names = fields_named.named
-        .iter()
-        .map(|field| {
-            let name = field.ident.as_ref().unwrap();
-            let name_str = name.to_string();
-            quote! { #name_str }
-        });
+pub fn generate_ordered_field_names_method(
+    fields_named: &FieldsNamed,
+) -> quote::__private::TokenStream {
+    let string_field_names = fields_named.named.iter().map(|field| {
+        let name = field.ident.as_ref().unwrap();
+        let name_str = name.to_string();
+        quote! { #name_str }
+    });
 
     quote! {
         fn ordered_field_names() -> &'static [&'static str] {

--- a/crates/bevy_interleave_macros/src/planar.rs
+++ b/crates/bevy_interleave_macros/src/planar.rs
@@ -1,14 +1,5 @@
 use quote::quote;
-use syn::{
-    Data,
-    DeriveInput,
-    Error,
-    Fields,
-    FieldsNamed,
-    Ident,
-    Result,
-};
-
+use syn::{Data, DeriveInput, Error, Fields, FieldsNamed, Ident, Result};
 
 pub fn generate_planar_struct(input: &DeriveInput) -> Result<quote::__private::TokenStream> {
     let name = &input.ident;
@@ -21,10 +12,16 @@ pub fn generate_planar_struct(input: &DeriveInput) -> Result<quote::__private::T
             _ => return Err(Error::new_spanned(input, "Unsupported struct type")),
         }
     } else {
-        return Err(Error::new_spanned(input, "Planar macro only supports structs"));
+        return Err(Error::new_spanned(
+            input,
+            "Planar macro only supports structs",
+        ));
     };
 
-    let field_names = fields_struct.named.iter().map(|f| f.ident.as_ref().unwrap());
+    let field_names = fields_struct
+        .named
+        .iter()
+        .map(|f| f.ident.as_ref().unwrap());
     let field_types = fields_struct.named.iter().map(|og| {
         let ty = &og.ty;
         quote! { Vec<#ty> }
@@ -68,11 +65,14 @@ pub fn generate_planar_struct(input: &DeriveInput) -> Result<quote::__private::T
                 &self.0
             }
         }
+
+        impl bevy::render::sync_component::SyncComponent for #planar_handle_name {
+            type Target = Self;
+        }
     };
 
     Ok(expanded)
 }
-
 
 pub fn generate_len_method(fields_named: &FieldsNamed) -> quote::__private::TokenStream {
     if let Some(first_field) = fields_named.named.first() {
@@ -99,8 +99,10 @@ pub fn generate_len_method(fields_named: &FieldsNamed) -> quote::__private::Toke
     }
 }
 
-
-pub fn generate_accessor_setter_methods(struct_name: &Ident, fields_named: &FieldsNamed) -> quote::__private::TokenStream {
+pub fn generate_accessor_setter_methods(
+    struct_name: &Ident,
+    fields_named: &FieldsNamed,
+) -> quote::__private::TokenStream {
     let packed_assignments = fields_named.named.iter().map(|field| {
         let name = field.ident.as_ref().unwrap();
         quote! { #name: self.#name[index].clone() }
@@ -124,23 +126,26 @@ pub fn generate_accessor_setter_methods(struct_name: &Ident, fields_named: &Fiel
     }
 }
 
+pub fn generate_conversion_methods(
+    struct_name: &Ident,
+    fields_named: &FieldsNamed,
+) -> quote::__private::TokenStream {
+    let (from_interleaved_fields, to_interleaved_fields_templates): (Vec<_>, Vec<_>) = fields_named
+        .named
+        .iter()
+        .map(|field| {
+            let name = field.ident.as_ref().unwrap();
 
-pub fn generate_conversion_methods(struct_name: &Ident, fields_named: &FieldsNamed) -> quote::__private::TokenStream {
-    let (
-        from_interleaved_fields,
-        to_interleaved_fields_templates
-    ): (Vec<_>, Vec<_>) = fields_named.named.iter().map(|field| {
-        let name = field.ident.as_ref().unwrap();
+            let from_interleaved_field = quote! {
+                #name: packed.iter().map(|x| x.#name.clone()).collect()
+            };
+            let to_interleaved_field_template = quote! {
+                #name: self.#name[index].clone()
+            };
 
-        let from_interleaved_field = quote! {
-            #name: packed.iter().map(|x| x.#name.clone()).collect()
-        };
-        let to_interleaved_field_template = quote! {
-            #name: self.#name[index].clone()
-        };
-
-        (from_interleaved_field, to_interleaved_field_template)
-    }).unzip();
+            (from_interleaved_field, to_interleaved_field_template)
+        })
+        .unzip();
 
     let to_interleaved_method = quote! {
         fn to_interleaved(&self) -> Vec<#struct_name> {
@@ -163,7 +168,6 @@ pub fn generate_conversion_methods(struct_name: &Ident, fields_named: &FieldsNam
 
     conversion_methods
 }
-
 
 pub fn generate_subset_method(fields_named: &FieldsNamed) -> proc_macro2::TokenStream {
     let mut new_planes_fields = Vec::new();

--- a/examples/app.rs
+++ b/examples/app.rs
@@ -2,7 +2,6 @@ use bevy::prelude::*;
 
 use bevy_interleave::prelude::*;
 
-
 #[derive(
     Clone,
     Debug,
@@ -27,14 +26,11 @@ pub struct MyStruct {
     pub array: [u32; 4],
 }
 
-
 fn main() {
     let mut app = App::new();
 
     app.add_plugins(DefaultPlugins);
-    app.add_plugins(
-        PlanarStoragePlugin::<MyStruct>::default(),
-    );
+    app.add_plugins(PlanarStoragePlugin::<MyStruct>::default());
 
     app.run();
 }

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,7 +1,6 @@
 use bevy::prelude::*;
 use bevy_interleave::prelude::*;
 
-
 #[derive(
     Clone,
     Debug,
@@ -26,12 +25,26 @@ pub struct MyStruct {
     pub array: [u32; 4],
 }
 
-
 fn main() {
     let interleaved = vec![
-        MyStruct { field: 0, field2: 1_u32, bool_field: true, array: [0, 1, 2, 3] },
-        MyStruct { field: 2, field2: 3_u32, bool_field: false, array: [4, 5, 6, 7] },
-        MyStruct { field: 4, field2: 5_u32, bool_field: true, array: [8, 9, 10, 11] },
+        MyStruct {
+            field: 0,
+            field2: 1_u32,
+            bool_field: true,
+            array: [0, 1, 2, 3],
+        },
+        MyStruct {
+            field: 2,
+            field2: 3_u32,
+            bool_field: false,
+            array: [4, 5, 6, 7],
+        },
+        MyStruct {
+            field: 4,
+            field2: 5_u32,
+            bool_field: true,
+            array: [8, 9, 10, 11],
+        },
     ];
 
     let planar = PlanarMyStruct::from_interleaved(interleaved);

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,5 @@
-pub use bevy::render::render_resource::TextureFormat;
 pub use bevy::image::TextureFormatPixelInfo;
+pub use bevy::render::render_resource::TextureFormat;
 
 pub use crate::interface::{
     GpuPlanar,
@@ -8,22 +8,13 @@ pub use crate::interface::{
     PlanarHandle,
     PlanarSync,
     PlanarTexture,
-    storage::{
-        PlanarStorageBindGroup,
-        PlanarStorageLayouts,
-        PlanarStoragePlugin,
-    },
     // texture::{
     //     PlanarTextureBindGroup,
     //     PlanarTextureLayouts,
     //     PlanarTexturePlugin,
     // },
     ReflectInterleaved,
+    storage::{PlanarStorageBindGroup, PlanarStorageLayouts, PlanarStoragePlugin},
 };
 
-pub use crate::macros::{
-    Planar,
-    ReflectInterleaved,
-    StorageBindings,
-    TextureBindings,
-};
+pub use crate::macros::{Planar, ReflectInterleaved, StorageBindings, TextureBindings};

--- a/test/lib.rs
+++ b/test/lib.rs
@@ -1,11 +1,7 @@
 use std::sync::{Arc, Mutex};
 
-use bevy::{
-    prelude::*,
-    winit::WinitPlugin,
-};
+use bevy::{prelude::*, winit::WinitPlugin};
 use bevy_interleave::prelude::*;
-
 
 #[derive(
     Clone,
@@ -34,15 +30,26 @@ pub struct MyStruct {
 #[derive(Resource, Default)]
 struct TestSuccess(Arc<Mutex<bool>>);
 
-
-fn setup_planar(
-    mut commands: Commands,
-    mut gaussian_assets: ResMut<Assets<PlanarMyStruct>>,
-) {
+fn setup_planar(mut commands: Commands, mut gaussian_assets: ResMut<Assets<PlanarMyStruct>>) {
     let planar = PlanarMyStruct::from_interleaved(vec![
-        MyStruct { field: 0, field2: 1_u32, bool_field: true, array: [0, 1, 2, 3] },
-        MyStruct { field: 2, field2: 3_u32, bool_field: false, array: [4, 5, 6, 7] },
-        MyStruct { field: 4, field2: 5_u32, bool_field: true, array: [8, 9, 10, 11] },
+        MyStruct {
+            field: 0,
+            field2: 1_u32,
+            bool_field: true,
+            array: [0, 1, 2, 3],
+        },
+        MyStruct {
+            field: 2,
+            field2: 3_u32,
+            bool_field: false,
+            array: [4, 5, 6, 7],
+        },
+        MyStruct {
+            field: 4,
+            field2: 5_u32,
+            bool_field: true,
+            array: [8, 9, 10, 11],
+        },
     ]);
 
     let planar_handle = gaussian_assets.add(planar);
@@ -62,7 +69,7 @@ fn setup_planar(
 // }
 
 fn check_storage_bind_group(
-    bind_group: Query<&PlanarStorageBindGroup::<MyStruct>>,
+    bind_group: Query<&PlanarStorageBindGroup<MyStruct>>,
     success: Res<TestSuccess>,
 ) {
     if bind_group.iter().count() > 0 {
@@ -70,10 +77,7 @@ fn check_storage_bind_group(
     }
 }
 
-fn test_timeout(
-    mut exit: MessageWriter<bevy::app::AppExit>,
-    mut frame_count: Local<u32>,
-) {
+fn test_timeout(mut exit: MessageWriter<bevy::app::AppExit>, mut frame_count: Local<u32>) {
     *frame_count += 1;
 
     if *frame_count > 5 {
@@ -81,20 +85,21 @@ fn test_timeout(
     }
 }
 
-
 #[test]
-#[cfg_attr(target_os = "macos", ignore = "WinitPlugin cannot run on non-main thread on macOS")]
+#[cfg_attr(
+    target_os = "macos",
+    ignore = "WinitPlugin cannot run on non-main thread on macOS"
+)]
 fn texture_bind_group() {
     let mut app = App::new();
 
-    let winit_plugin = WinitPlugin { run_on_any_thread: true };
+    let winit_plugin = WinitPlugin {
+        run_on_any_thread: true,
+    };
 
     app.add_plugins((
-        DefaultPlugins
-            .set(winit_plugin),
-        bevy::app::ScheduleRunnerPlugin::run_loop(
-            std::time::Duration::from_millis(50)
-        ),
+        DefaultPlugins.set(winit_plugin),
+        bevy::app::ScheduleRunnerPlugin::run_loop(std::time::Duration::from_millis(50)),
     ));
     app.add_plugins(
         PlanarStoragePlugin::<MyStruct>::default(),


### PR DESCRIPTION
## Summary

- update `bevy_interleave`, `bevy_interleave_interface`, and `bevy_interleave_macros` to `0.10.0`
- migrate Bevy dependencies to released `bevy = "0.19"` and `wgpu = "29"`
- add Bevy 0.19 `SyncComponent` support for generated planar handles
- enable the `x11` dev feature so tests and examples compile `bevy_winit` on Linux
- apply rustfmt normalization across the crate

## Validation

- `cargo check --workspace`
- `cargo test --workspace`
- `cargo build --workspace --examples`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `cargo tree --workspace --edges normal -i bevy`
- `git diff --check`

## Published

Published to crates.io in dependency order:

- `bevy_interleave_interface v0.10.0`
- `bevy_interleave_macros v0.10.0`
- `bevy_interleave v0.10.0`
